### PR TITLE
Add --no-cache flag to apk add in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM amd64/alpine:edge
 
-RUN apk add --update \
+RUN apk add --update --no-cache \
 ffmpeg \
 imagemagick \
 nodejs-current \


### PR DESCRIPTION
This will increase build speed and decrease image size a little bit