### PR TITLE
fix: undefined as field name

### DIFF
--- a/commands/util/user.js
+++ b/commands/util/user.js
@@ -37,8 +37,12 @@ module.exports = {
     embed.addField('Tag', user.tag, true);
     if (guildMember && guildMember.nickname) embed.addField('Nickname', guildMember.nickname, true);
     if (user.presence.status) embed.addField('Status', user.presence.status, true); // TODO: hide this, if we don't have any common guilds with this user, as the presence will be unknown then thus always displaying offline
-    if (user.presence.activity) embed.addField(activities[user.presence.activity.type], user.presence.activity.name, true);
-
+    if (user.presence.activity) {
+      if (user.presence.activity.name === 'Custom Status')
+        embed.addField('Custom Status', user.presence.activity.state, true);
+      else
+        embed.addField(activities[user.presence.activity.type], user.presence.activity.name, true);
+    }
     embed.addField('Bot', (user.bot) ? 'Yes' : 'No', true);
 
     if (ctx.guild && user.id !== ctx.main.api.user.id && user.id !== ctx.author.id) {

--- a/commands/util/user.js
+++ b/commands/util/user.js
@@ -38,10 +38,8 @@ module.exports = {
     if (guildMember && guildMember.nickname) embed.addField('Nickname', guildMember.nickname, true);
     if (user.presence.status) embed.addField('Status', user.presence.status, true); // TODO: hide this, if we don't have any common guilds with this user, as the presence will be unknown then thus always displaying offline
     if (user.presence.activity) {
-      if (user.presence.activity.name === 'Custom Status')
-        embed.addField('Custom Status', user.presence.activity.state, true);
-      else
-        embed.addField(activities[user.presence.activity.type], user.presence.activity.name, true);
+      if (user.presence.activity.name === 'Custom Status') embed.addField('Custom Status', user.presence.activity.state, true);
+      else embed.addField(activities[user.presence.activity.type], user.presence.activity.name, true);
     }
     embed.addField('Bot', (user.bot) ? 'Yes' : 'No', true);
 


### PR DESCRIPTION
As of the current version of discord.js v12 (16db92ede8dc164346eca8482ea008cb21032c7b), custom statuses do not have their own [ActivityType](https://discord.js.org/#/docs/main/master/typedef/ActivityType).
This causes the embed for the user command to display `undefined` as field name for the playing status, because user.presence.activity.type will be `undefined`.
This Pull Request checks if the activity name is 'Custom Status' (which is the case for a custom status) and adds the custom status state as field value. If the user has a normal presence, it will use the playing status as field name and value as before.<br/>
![image](https://user-images.githubusercontent.com/30553356/67444106-fc52ce80-f607-11e9-832e-7800f1b1c6d0.png)<br/>
It is probably not a good idea to hardcode the string "Custom Status" and as soon as custom statuses have their own ActivityType, I believe it should be added to the constant `activities` on line 1-5 of the file commands/util/user.js.

![image](https://user-images.githubusercontent.com/30553356/67444202-5358a380-f608-11e9-96c4-20cabda1c80e.png)
